### PR TITLE
autodetect bicolor displays

### DIFF
--- a/epdlib/Screen.py
+++ b/epdlib/Screen.py
@@ -308,6 +308,8 @@ class Screen:
             logging.error(f'failed to init epd: {e}')
             
         logging.info(f'{self.epd} initialized')
+        self.buffer_no_image = self.epd.getbuffer(
+            Image.new('L', self.resolution, 255))
         return True
     
     def clearEPD(self):
@@ -342,7 +344,13 @@ class Screen:
         try:
             logging.debug('writing to epd')
 #             epd.display(epd.getbuffer(self.image))
-            epd.display(epd.getbuffer(image))
+            # the presence of 'bc' in waveshare module name indicates a
+            # bicolor display
+            if 'bc' in self.epd.__class__.__module__:
+                epd.display(self.epd.getbuffer(image), self.buffer_no_image)
+            else:
+                epd.display(self.epd.getbuffer(image))
+
             self.update.update()
             if sleep:
                 epd.sleep()


### PR DESCRIPTION
This allowed me to successfully use my waveshare bicolor display with epd7in5bc_V2.

This kind of introspection isn't fantastic from a code quality standpoint, but I'm still sharing it with you @txoof .

I also sync'ed the waveshare_epd directory with Waveshares repo at, because I noticed that a change had been made in the sleep() method since you did a copy (see https://github.com/waveshare/e-Paper/commit/751a9fb93fdd486511222777b0070c51bf436386#diff-19259a5328cddb0511e7b66e73c4138fR171).  I haven't checked how things work with the older code.

